### PR TITLE
Merge exit-vehicle-on-damage onto alpha-0.1-dev

### DIFF
--- a/src/main/java/dev/symphony/harmony/ModTags.java
+++ b/src/main/java/dev/symphony/harmony/ModTags.java
@@ -5,6 +5,6 @@ import net.minecraft.registry.RegistryKeys;
 import net.minecraft.registry.tag.TagKey;
 
 public class ModTags {
+    // Add documentation abt data-driven vehicles tag maybe :P
     public static final TagKey<EntityType<?>> VEHICLES = TagKey.of(RegistryKeys.ENTITY_TYPE, Harmony.id("vehicles"));
-
 }

--- a/src/main/java/dev/symphony/harmony/ModTags.java
+++ b/src/main/java/dev/symphony/harmony/ModTags.java
@@ -1,0 +1,10 @@
+package dev.symphony.harmony;
+
+import net.minecraft.entity.EntityType;
+import net.minecraft.registry.RegistryKeys;
+import net.minecraft.registry.tag.TagKey;
+
+public class ModTags {
+    public static final TagKey<EntityType<?>> VEHICLES = TagKey.of(RegistryKeys.ENTITY_TYPE, Harmony.id("vehicles"));
+
+}

--- a/src/main/java/dev/symphony/harmony/config/HarmonyConfig.java
+++ b/src/main/java/dev/symphony/harmony/config/HarmonyConfig.java
@@ -7,6 +7,7 @@ public class HarmonyConfig extends MidnightConfig {
 
     // Transportation
     public static final String TRANS = "transportation";
+    @Entry(category = TRANS) public static boolean exitVehicleOnDamage = true;
     @Entry(category = TRANS) public static boolean vehiclesMoveThroughLeaves = true;
     @Entry(category = TRANS, isSlider = true, min = 0f, max = 1f) public static float leafSpeedFactor = 0.85f;
 

--- a/src/main/java/dev/symphony/harmony/mixin/transportation/ExitVehicleOnDamage.java
+++ b/src/main/java/dev/symphony/harmony/mixin/transportation/ExitVehicleOnDamage.java
@@ -11,6 +11,8 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+// FEATURE: Mobs exit (some) vehicles when damaged
+// AUTHORS: Trigam, Flatkat
 @Mixin(LivingEntity.class)
 public class ExitVehicleOnDamage {
     @Inject(

--- a/src/main/java/dev/symphony/harmony/mixin/transportation/ExitVehicleOnDamage.java
+++ b/src/main/java/dev/symphony/harmony/mixin/transportation/ExitVehicleOnDamage.java
@@ -11,7 +11,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-// FEATURE: Mobs exit (some) vehicles when damaged
+// FEATURE: Mobs exit vehicles when damaged (by default only the ones mobs can auto-mount on on vanilla, configurable via datapack)
 // AUTHORS: Trigam, Flatkat
 @Mixin(LivingEntity.class)
 public class ExitVehicleOnDamage {

--- a/src/main/java/dev/symphony/harmony/mixin/transportation/ExitVehicleOnDamage.java
+++ b/src/main/java/dev/symphony/harmony/mixin/transportation/ExitVehicleOnDamage.java
@@ -1,0 +1,34 @@
+package dev.symphony.harmony.mixin.transportation;
+
+import dev.symphony.harmony.ModTags;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.damage.DamageSource;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(LivingEntity.class)
+public class ExitVehicleOnDamage {
+    @Inject(
+            method = "damage",
+            at = @At( value = "TAIL" )
+    )
+    private void exitVehicleOnDamage(DamageSource source, float amount, CallbackInfoReturnable<Boolean> cir) {
+        LivingEntity entity = ((LivingEntity) (Object) this);
+        if (amount <= 0) return;
+        if (entity.isPlayer()) return;
+
+        Entity vehicle = entity.getVehicle();
+        if (vehicle == null) return;
+        EntityType<?> vehicleType = vehicle.getType();
+
+        if (vehicleType.isIn(ModTags.VEHICLES)) {
+            entity.stopRiding();
+        }
+
+
+    }
+}

--- a/src/main/java/dev/symphony/harmony/mixin/transportation/ExitVehicleOnDamage.java
+++ b/src/main/java/dev/symphony/harmony/mixin/transportation/ExitVehicleOnDamage.java
@@ -1,6 +1,7 @@
 package dev.symphony.harmony.mixin.transportation;
 
 import dev.symphony.harmony.ModTags;
+import dev.symphony.harmony.config.HarmonyConfig;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
@@ -17,18 +18,19 @@ public class ExitVehicleOnDamage {
             at = @At( value = "TAIL" )
     )
     private void exitVehicleOnDamage(DamageSource source, float amount, CallbackInfoReturnable<Boolean> cir) {
-        LivingEntity entity = ((LivingEntity) (Object) this);
-        if (amount <= 0) return;
-        if (entity.isPlayer()) return;
+        if(HarmonyConfig.exitVehicleOnDamage) {
+            LivingEntity entity = ((LivingEntity) (Object) this);
+            if (amount <= 0) return;
+            if (entity.isPlayer()) return;
 
-        Entity vehicle = entity.getVehicle();
-        if (vehicle == null) return;
-        EntityType<?> vehicleType = vehicle.getType();
+            Entity vehicle = entity.getVehicle();
+            if (vehicle == null) return;
+            EntityType<?> vehicleType = vehicle.getType();
 
-        if (vehicleType.isIn(ModTags.VEHICLES)) {
-            entity.stopRiding();
+            if (vehicleType.isIn(ModTags.VEHICLES)) {
+                entity.stopRiding();
+            }
         }
-
 
     }
 }

--- a/src/main/resources/assets/harmony/lang/en_us.json
+++ b/src/main/resources/assets/harmony/lang/en_us.json
@@ -6,6 +6,7 @@
     "harmony.midnightconfig.category.harmony": "Harmony",
 
     "harmony.midnightconfig.category.transportation": "Transportation",
+    "harmony.midnightconfig.exitVehicleOnDamage": "Mobs exit vehicles when taking damage",
     "harmony.midnightconfig.vehiclesMoveThroughLeaves": "Rideable mobs can move through leaves when ridden",
     "harmony.midnightconfig.leafSpeedFactor": "Rideable mob speed percentage while inside leaves",
 

--- a/src/main/resources/data/harmony/tags/entity_type/vehicles.json
+++ b/src/main/resources/data/harmony/tags/entity_type/vehicles.json
@@ -1,0 +1,8 @@
+{
+    "replace": false,
+    "values": [
+      "minecraft:boat",
+      "minecraft:chest_boat",
+      "minecraft:minecart"
+    ]
+}

--- a/src/main/resources/harmony.mixins.json
+++ b/src/main/resources/harmony.mixins.json
@@ -1,13 +1,12 @@
 {
-	"required": true,
-	"package": "dev.symphony.harmony.mixin",
-	"compatibilityLevel": "JAVA_21",
-
-	"mixins": [
-		"transportation.VehiclesMoveThroughLeaves"
-	],
-
-	"injectors": {
-		"defaultRequire": 1
+  "required": true,
+  "package": "dev.symphony.harmony.mixin",
+  "compatibilityLevel": "JAVA_21",
+  "mixins": [
+    "transportation.ExitVehicleOnDamage",
+    "transportation.VehiclesMoveThroughLeaves"
+  ],
+  "injectors": {
+    "defaultRequire": 1
 	}
 }


### PR DESCRIPTION
Adds Mobs exiting vehicle when recieving damage. Its toggable via config and the mobs with the "vehicle" tag can be changed via datapack (this is an intended feature so other modders can add their own compat manually, this could be reviewed and be replaced with a config option instead though, alongside with the current list of vehicles).