### PR TITLE
Add beaconsAffectTamedMobs

### DIFF
--- a/src/main/java/dev/symphony/harmony/config/HarmonyConfig.java
+++ b/src/main/java/dev/symphony/harmony/config/HarmonyConfig.java
@@ -25,4 +25,8 @@ public class HarmonyConfig extends MidnightConfig {
     // Redstone
     public static final String REDSTONE = "redstone";
     @Entry(category = REDSTONE) public static boolean oneTickCopperBulbDelay = true;
+
+    // Potions
+    public static final String POTIONS = "potions";
+    @Entry(category = POTIONS) public static boolean beaconsAffectTamedMobs = true;
 }

--- a/src/main/java/dev/symphony/harmony/mixin/potions/BeaconBlockEntityMixin.java
+++ b/src/main/java/dev/symphony/harmony/mixin/potions/BeaconBlockEntityMixin.java
@@ -1,0 +1,50 @@
+package dev.symphony.harmony.mixin.potions;
+
+import com.llamalad7.mixinextras.sugar.Local;
+import dev.symphony.harmony.config.HarmonyConfig;
+import net.minecraft.block.entity.BeaconBlockEntity;
+import net.minecraft.entity.effect.StatusEffect;
+import net.minecraft.entity.effect.StatusEffectInstance;
+import net.minecraft.entity.passive.TameableEntity;
+import net.minecraft.registry.entry.RegistryEntry;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Box;
+import net.minecraft.world.World;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.List;
+import java.util.Objects;
+
+// FEATURE: Gives the beacon's effect to tamed entities as well as players.
+// AUTHOR: axialeaa
+@Mixin(BeaconBlockEntity.class)
+public class BeaconBlockEntityMixin {
+
+    @Inject(method = "applyPlayerEffects", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;getNonSpectatingEntities(Ljava/lang/Class;Lnet/minecraft/util/math/Box;)Ljava/util/List;"))
+    private static void applyTamedEntityEffects(World world, BlockPos pos, int beaconLevel, @Nullable RegistryEntry<StatusEffect> primaryEffect, @Nullable RegistryEntry<StatusEffect> secondaryEffect, CallbackInfo ci,
+        @Local Box box, @Local(ordinal = 1) int amplifier, @Local(ordinal = 2) int duration
+    ) {
+        if (!HarmonyConfig.beaconsAffectTamedMobs)
+            return;
+
+        List<TameableEntity> tameableEntities = world.getEntitiesByClass(TameableEntity.class, box, TameableEntity::isTamed);
+
+        StatusEffectInstance primary = new StatusEffectInstance(primaryEffect, duration, amplifier, true, true);
+        StatusEffectInstance secondary = null;
+
+        if (beaconLevel >= 4 && secondaryEffect != null && !Objects.equals(primaryEffect, secondaryEffect))
+            secondary = new StatusEffectInstance(secondaryEffect, duration, 0, true, true);
+
+        for (TameableEntity tameableEntity : tameableEntities) {
+            tameableEntity.addStatusEffect(primary);
+
+            if (secondary != null)
+                tameableEntity.addStatusEffect(secondary);
+        }
+    }
+
+}

--- a/src/main/java/dev/symphony/harmony/mixin/redstone/OneTickCopperBulbDelay.java
+++ b/src/main/java/dev/symphony/harmony/mixin/redstone/OneTickCopperBulbDelay.java
@@ -37,9 +37,7 @@ public class OneTickCopperBulbDelay extends Block {
     //Calling update
     @Override
     protected void scheduledTick(BlockState state, ServerWorld world, BlockPos pos, Random random) {
-        if (world instanceof ServerWorld) {
-            this.update(state, world, pos);
-        }
+        this.update(state, world, pos);
     }
 
 }

--- a/src/main/java/dev/symphony/harmony/mixin/redstone/OneTickCopperBulbDelay.java
+++ b/src/main/java/dev/symphony/harmony/mixin/redstone/OneTickCopperBulbDelay.java
@@ -37,7 +37,9 @@ public class OneTickCopperBulbDelay extends Block {
     //Calling update
     @Override
     protected void scheduledTick(BlockState state, ServerWorld world, BlockPos pos, Random random) {
-        this.update(state, world, pos);
+        if (world instanceof ServerWorld) {
+            this.update(state, world, pos);
+        }
     }
 
 }

--- a/src/main/resources/assets/harmony/lang/en_us.json
+++ b/src/main/resources/assets/harmony/lang/en_us.json
@@ -22,5 +22,8 @@
     "harmony.midnightconfig.armorStandSticks": "Number of sticks required to equip Armor Stands with arms",
 
     "harmony.midnightconfig.category.redstone": "Redstone",
-    "harmony.midnightconfig.oneTickCopperBulbDelay": "Copper bulbs have a 1 tick delay"
+    "harmony.midnightconfig.oneTickCopperBulbDelay": "Copper bulbs have a 1 tick delay",
+
+    "harmony.midnightconfig.category.potions": "Potions",
+    "harmony.midnightconfig.beaconsAffectTamedMobs": "Beacon effects apply to tamed animals as well as players."
 }

--- a/src/main/resources/harmony.mixins.json
+++ b/src/main/resources/harmony.mixins.json
@@ -6,6 +6,7 @@
     "transportation.ExitVehicleOnDamage",
     "transportation.HorseArmorPreventsBucking",
     "building.ArmorStandStickArms",
+    "potions.BeaconBlockEntityMixin",
     "redstone.OneTickCopperBulbDelay",
     "food.GlowBerryMixin"
   ],


### PR DESCRIPTION
Implemented and tested, but food for thought: some effects are pretty useless on non-player entities like haste for example. Should we filter those off? Maybe the only effect that should apply to tamed mobs is secondary regeneration, since selecting that sacrifices the potency of the primary beacon effect.