### PR TITLE
Add husksDropSandOnConvert

### DIFF
--- a/src/main/java/dev/symphony/harmony/Harmony.java
+++ b/src/main/java/dev/symphony/harmony/Harmony.java
@@ -3,6 +3,8 @@ package dev.symphony.harmony;
 import dev.symphony.harmony.config.HarmonyConfig;
 import dev.symphony.harmony.config.HarmonyConfigCondition;
 import dev.symphony.harmony.item.ModifyItems;
+import dev.symphony.harmony.loot.HarmonyLootContextTypes;
+import dev.symphony.harmony.loot.HarmonyLootTables;
 import eu.midnightdust.lib.config.MidnightConfig;
 import net.fabricmc.api.ModInitializer;
 
@@ -32,5 +34,8 @@ public class Harmony implements ModInitializer {
 
 		// gay shit
 		ModifyItems.init();
+
+		HarmonyLootTables.noop();
+		HarmonyLootContextTypes.noop();
 	}
 }

--- a/src/main/java/dev/symphony/harmony/config/HarmonyConfig.java
+++ b/src/main/java/dev/symphony/harmony/config/HarmonyConfig.java
@@ -40,4 +40,8 @@ public class HarmonyConfig extends MidnightConfig {
         itemDespawnTimeEasy = (int) TimeUnit.MINUTES.toSeconds(20),
         itemDespawnTimeNormal = (int) TimeUnit.MINUTES.toSeconds(10),
         itemDespawnTimeHard = (int) TimeUnit.MINUTES.toSeconds(5);
+
+    // Mobs
+    public static final String MOBS = "mobs";
+    @Entry(category = MOBS) public static boolean husksDropSandOnConvert = true;
 }

--- a/src/main/java/dev/symphony/harmony/loot/HarmonyLootContextTypes.java
+++ b/src/main/java/dev/symphony/harmony/loot/HarmonyLootContextTypes.java
@@ -14,15 +14,9 @@ public class HarmonyLootContextTypes {
         .build()
     );
 
-    @SuppressWarnings("UnreachableCode")
     private static LootContextType register(String name, LootContextType type) {
         Identifier id = Harmony.id(name);
-        LootContextType lootContextType = LootContextTypesAccessor.getMap().put(id, type);
-
-        if (lootContextType == null)
-            return type;
-
-        throw new IllegalStateException("Loot table parameter set %s is already registered".formatted(id));
+        return LootContextTypesAccessor.getMap().put(id, type);
     }
 
     public static void noop() {}

--- a/src/main/java/dev/symphony/harmony/loot/HarmonyLootContextTypes.java
+++ b/src/main/java/dev/symphony/harmony/loot/HarmonyLootContextTypes.java
@@ -14,9 +14,12 @@ public class HarmonyLootContextTypes {
         .build()
     );
 
+    @SuppressWarnings("UnreachableCode")
     private static LootContextType register(String name, LootContextType type) {
         Identifier id = Harmony.id(name);
-        return LootContextTypesAccessor.getMap().put(id, type);
+        LootContextTypesAccessor.getMap().put(id, type);
+
+        return type;
     }
 
     public static void noop() {}

--- a/src/main/java/dev/symphony/harmony/loot/HarmonyLootContextTypes.java
+++ b/src/main/java/dev/symphony/harmony/loot/HarmonyLootContextTypes.java
@@ -1,0 +1,30 @@
+package dev.symphony.harmony.loot;
+
+import dev.symphony.harmony.Harmony;
+import dev.symphony.harmony.mixin.accessor.LootContextTypesAccessor;
+import net.minecraft.loot.context.LootContextParameters;
+import net.minecraft.loot.context.LootContextType;
+import net.minecraft.util.Identifier;
+
+public class HarmonyLootContextTypes {
+
+    public static final LootContextType CONVERSION = register("conversion", LootContextType.create()
+        .require(LootContextParameters.ORIGIN)
+        .allow(LootContextParameters.THIS_ENTITY)
+        .build()
+    );
+
+    @SuppressWarnings("UnreachableCode")
+    private static LootContextType register(String name, LootContextType type) {
+        Identifier id = Harmony.id(name);
+        LootContextType lootContextType = LootContextTypesAccessor.getMap().put(id, type);
+
+        if (lootContextType == null)
+            return type;
+
+        throw new IllegalStateException("Loot table parameter set %s is already registered".formatted(id));
+    }
+
+    public static void noop() {}
+
+}

--- a/src/main/java/dev/symphony/harmony/loot/HarmonyLootTables.java
+++ b/src/main/java/dev/symphony/harmony/loot/HarmonyLootTables.java
@@ -1,0 +1,23 @@
+package dev.symphony.harmony.loot;
+
+import dev.symphony.harmony.Harmony;
+import dev.symphony.harmony.mixin.accessor.LootTablesAccessor;
+import net.minecraft.loot.LootTable;
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.registry.RegistryKeys;
+import net.minecraft.util.Identifier;
+
+public class HarmonyLootTables {
+
+    public static final RegistryKey<LootTable> HUSK_CONVERSION = register("conversion/husk");
+
+    private static RegistryKey<LootTable> register(String name) {
+        Identifier id = Harmony.id(name);
+        RegistryKey<LootTable> registryKey = RegistryKey.of(RegistryKeys.LOOT_TABLE, id);
+
+        return LootTablesAccessor.invokeRegisterLootTable(registryKey);
+    }
+
+    public static void noop() {}
+
+}

--- a/src/main/java/dev/symphony/harmony/mixin/accessor/LootContextTypesAccessor.java
+++ b/src/main/java/dev/symphony/harmony/mixin/accessor/LootContextTypesAccessor.java
@@ -1,0 +1,18 @@
+package dev.symphony.harmony.mixin.accessor;
+
+import com.google.common.collect.BiMap;
+import net.minecraft.loot.context.LootContextType;
+import net.minecraft.loot.context.LootContextTypes;
+import net.minecraft.util.Identifier;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(LootContextTypes.class)
+public interface LootContextTypesAccessor {
+
+    @Accessor("MAP")
+    static BiMap<Identifier, LootContextType> getMap() {
+        throw new AssertionError();
+    }
+
+}

--- a/src/main/java/dev/symphony/harmony/mixin/accessor/LootTablesAccessor.java
+++ b/src/main/java/dev/symphony/harmony/mixin/accessor/LootTablesAccessor.java
@@ -1,0 +1,17 @@
+package dev.symphony.harmony.mixin.accessor;
+
+import net.minecraft.loot.LootTable;
+import net.minecraft.loot.LootTables;
+import net.minecraft.registry.RegistryKey;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+@Mixin(LootTables.class)
+public interface LootTablesAccessor {
+
+    @Invoker("registerLootTable")
+    static RegistryKey<LootTable> invokeRegisterLootTable(RegistryKey<LootTable> key) {
+        throw new AssertionError();
+    }
+
+}

--- a/src/main/java/dev/symphony/harmony/mixin/mobs/HuskEntityMixin.java
+++ b/src/main/java/dev/symphony/harmony/mixin/mobs/HuskEntityMixin.java
@@ -1,0 +1,63 @@
+package dev.symphony.harmony.mixin.mobs;
+
+import dev.symphony.harmony.config.HarmonyConfig;
+import dev.symphony.harmony.loot.HarmonyLootContextTypes;
+import dev.symphony.harmony.loot.HarmonyLootTables;
+import net.minecraft.entity.mob.HuskEntity;
+import net.minecraft.entity.mob.ZombieEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.loot.LootTable;
+import net.minecraft.loot.context.LootContextParameterSet;
+import net.minecraft.loot.context.LootContextParameters;
+import net.minecraft.registry.ReloadableRegistries;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.world.GameRules;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/**
+ * Husks drop sand when they convert into zombies in water.
+ * @author axialeaa
+ * @see HarmonyLootTables
+ * @see HarmonyLootContextTypes
+ */
+@Mixin(HuskEntity.class)
+public class HuskEntityMixin extends ZombieEntity {
+
+    public HuskEntityMixin(World world) {
+        super(world);
+    }
+
+    @Inject(method = "convertInWater", at = @At("HEAD"))
+    private void dropLootOnConvert(CallbackInfo info) {
+        if (!HarmonyConfig.husksDropSandOnConvert || !(this.getWorld() instanceof ServerWorld serverWorld))
+            return;
+
+        GameRules gameRules = serverWorld.getGameRules();
+
+        if (gameRules.getBoolean(GameRules.DO_MOB_LOOT))
+            this.dropLoot(serverWorld);
+    }
+
+    @Unique
+    private void dropLoot(ServerWorld serverWorld) {
+        MinecraftServer server = serverWorld.getServer();
+        ReloadableRegistries.Lookup registries = server.getReloadableRegistries();
+
+        LootTable lootTable = registries.getLootTable(HarmonyLootTables.HUSK_CONVERSION);
+
+        LootContextParameterSet lootContextParameterSet = new LootContextParameterSet.Builder(serverWorld)
+            .add(LootContextParameters.ORIGIN, this.getPos())
+            .add(LootContextParameters.THIS_ENTITY, this)
+            .build(HarmonyLootContextTypes.CONVERSION);
+
+        for (ItemStack itemStack : lootTable.generateLoot(lootContextParameterSet))
+            this.dropStack(itemStack, this.getHeight());
+    }
+
+}

--- a/src/main/java/dev/symphony/harmony/mixin/mobs/HuskEntityMixin.java
+++ b/src/main/java/dev/symphony/harmony/mixin/mobs/HuskEntityMixin.java
@@ -45,13 +45,13 @@ public class HuskEntityMixin extends ZombieEntity {
     }
 
     @Unique
-    private void dropLoot(ServerWorld serverWorld) {
-        MinecraftServer server = serverWorld.getServer();
+    private void dropLoot(ServerWorld world) {
+        MinecraftServer server = world.getServer();
         ReloadableRegistries.Lookup registries = server.getReloadableRegistries();
 
         LootTable lootTable = registries.getLootTable(HarmonyLootTables.HUSK_CONVERSION);
 
-        LootContextParameterSet lootContextParameterSet = new LootContextParameterSet.Builder(serverWorld)
+        LootContextParameterSet lootContextParameterSet = new LootContextParameterSet.Builder(world)
             .add(LootContextParameters.ORIGIN, this.getPos())
             .add(LootContextParameters.THIS_ENTITY, this)
             .build(HarmonyLootContextTypes.CONVERSION);

--- a/src/main/resources/assets/harmony/lang/en_us.json
+++ b/src/main/resources/assets/harmony/lang/en_us.json
@@ -30,5 +30,8 @@
     "harmony.midnightconfig.category.combat": "Combat",
     "harmony.midnightconfig.itemDespawnTimeEasy": "Time for dropped items to despawn in easy/peaceful.",
     "harmony.midnightconfig.itemDespawnTimeNormal": "Time for dropped items to despawn in normal.",
-    "harmony.midnightconfig.itemDespawnTimeHard": "Time for dropped items to despawn in hard."
+    "harmony.midnightconfig.itemDespawnTimeHard": "Time for dropped items to despawn in hard.",
+
+    "harmony.midnightconfig.category.mobs": "Mobs",
+    "harmony.midnightconfig.husksDropSandOnConvert": "Husks drop sand when converting into zombies."
 }

--- a/src/main/resources/data/harmony/loot_table/conversion/husk.json
+++ b/src/main/resources/data/harmony/loot_table/conversion/husk.json
@@ -1,0 +1,49 @@
+{
+  "type": "harmony:conversion",
+  "pools": [
+    {
+      "rolls": 2,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:sand",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 0,
+                "max": 1
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:sand",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 1,
+                "max": 3
+              },
+              "add": true,
+              "conditions": [
+                {
+                  "condition": "minecraft:entity_properties",
+                  "entity": "this",
+                  "predicate": {
+                    "flags": {
+                      "is_baby": false
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "random_sequence": "harmony:conversion/husk"
+}

--- a/src/main/resources/data/harmony/loot_table/conversion/husk.json
+++ b/src/main/resources/data/harmony/loot_table/conversion/husk.json
@@ -2,7 +2,6 @@
   "type": "harmony:conversion",
   "pools": [
     {
-      "rolls": 2,
       "entries": [
         {
           "type": "minecraft:item",
@@ -12,7 +11,7 @@
               "function": "minecraft:set_count",
               "count": {
                 "min": 0,
-                "max": 1
+                "max": 2
               }
             }
           ]
@@ -24,8 +23,8 @@
             {
               "function": "minecraft:set_count",
               "count": {
-                "min": 1,
-                "max": 3
+                "min": 2,
+                "max": 6
               },
               "add": true,
               "conditions": [

--- a/src/main/resources/data/harmony/loot_table/conversion/husk.json
+++ b/src/main/resources/data/harmony/loot_table/conversion/husk.json
@@ -2,6 +2,7 @@
   "type": "harmony:conversion",
   "pools": [
     {
+      "rolls": 1,
       "entries": [
         {
           "type": "minecraft:item",

--- a/src/main/resources/harmony.mixins.json
+++ b/src/main/resources/harmony.mixins.json
@@ -3,9 +3,12 @@
   "package": "dev.symphony.harmony.mixin",
   "compatibilityLevel": "JAVA_21",
   "mixins": [
+    "accessor.LootContextTypesAccessor",
+    "accessor.LootTablesAccessor",
     "building.ArmorStandStickArms",
     "combat.ItemEntityMixin",
     "food.GlowBerryMixin",
+    "mobs.HuskEntityMixin",
     "potions.BeaconBlockEntityMixin",
     "redstone.AbstractBlockImplMixin",
     "redstone.OneTickCopperBulbDelay",


### PR DESCRIPTION
Husks drop some sand when they convert into zombies. Babies can drop 0-2 sand, while adults can drop 2-8. Data-driven using a loot table with a custom context type specifically to handle "conversion" drops, which may be a little over-the-top for such a small feature? Perhaps we'll be able to re-use it somewhere else in the future; special events that happen when a mob converts are rather untapped right now.

Edit: the feature tracker suggests making husks periodically drop sand throughout their conversion process, but I felt this implementation was a little more vanilla-friendly. Lmk if you don't agree.