### PR TITLE
Remove parrot perching on creative flight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Sometimes using /give command may create a copy of the given item that cant be picked up. This bug hasnt been able to be consistently reproduced and debugged yet.
     - Current workarounds: Disable the "Change items despawn time depending on difficulty" feature.
 
-#### Mobs
-
-- Parrots become invisible for vanilla clients if the player starts flying on creative mode with parrots on their shoulders until client reconnects or the parrots fly off of the player.
-    - Current workaround: Install Harmony on the client or disable "Parrots dismount under fewer restrictions"
-
 ## [Unreleased]
 
 ### Added

--- a/src/main/java/dev/symphony/harmony/mixin/mobs/permissive_parrot_perching/PlayerEntityMixin.java
+++ b/src/main/java/dev/symphony/harmony/mixin/mobs/permissive_parrot_perching/PlayerEntityMixin.java
@@ -35,11 +35,6 @@ public abstract class PlayerEntityMixin extends EntityImplMixin {
         return Integer.MIN_VALUE;
     }
 
-    @ModifyExpressionValue(method = "tickMovement", slice = @Slice(from = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/PlayerEntity;updateShoulderEntity(Lnet/minecraft/nbt/NbtCompound;)V", ordinal = 0)), at = @At(value = "FIELD", target = "Lnet/minecraft/entity/player/PlayerAbilities;flying:Z"))
-    private boolean modifyIsFlying(boolean original) {
-        return !HarmonyConfig.permissiveParrotPerching && original;
-    }
-
     @Inject(method = "startGliding", at = @At("HEAD"))
     private void dropOnStartedFallFlying(CallbackInfo ci) {
         World world = this.asLivingEntity.getWorld();


### PR DESCRIPTION
Fixed as we cannot make the parrot stay on the player's shoulder when they start to fly on creative mode without modding the client. 
This fixes the known issue of the parrot becoming invisible on vanilla clients when trying to fly with one on your shoulder.