### PR TITLE
Port to 1.21.4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,9 +4,10 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.21.3
-yarn_mappings=1.21.3+build.2
-loader_version=0.16.7
+minecraft_version=1.21.4
+yarn_mappings=1.21.4+build.1
+loader_version=0.16.9
+
 
 # Mod Properties
 mod_version=0.0.1-alpha+mc1.21.3
@@ -14,5 +15,5 @@ maven_group=dev.symphony.harmony
 archives_base_name=harmony
 
 # Dependencies
-fabric_version=0.106.1+1.21.3
-midnightlib_version = 1.6.4-fabric
+fabric_version=0.110.5+1.21.4
+midnightlib_version = 1.6.6-fabric


### PR DESCRIPTION
Took so much work and effort fr, breaking changes everywhere

(Perfect match, only updating gradle.properties needed)

Despite this other things prob arent fully compatible so lets fully drop 1.21.3 to support this version exclusively like always. 